### PR TITLE
Feature/model notify extension

### DIFF
--- a/Components/Model/Cart.php
+++ b/Components/Model/Cart.php
@@ -81,4 +81,23 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Cart extends Shopw
 	{
 		return $this->_lineItems;
 	}
+
+	/**
+	 * Sets the line items for the basket.
+	 *
+	 * The line items must be an array of Shopware_Plugins_Frontend_NostoTagging_Components_Model_Cart_LineItem
+	 *
+	 * Usage:
+	 * $object->setLineItems([new Shopware_Plugins_Frontend_NostoTagging_Components_Model_Cart_LineItem(), ...]);
+	 *
+	 * @param Shopware_Plugins_Frontend_NostoTagging_Components_Model_Cart_LineItem[] $lineItems the line items.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setLineItems($lineItems)
+	{
+		$this->_lineItems = $lineItems;
+
+		return $this;
+	}
 }

--- a/Components/Model/Cart.php
+++ b/Components/Model/Cart.php
@@ -63,6 +63,15 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Cart extends Shopw
 			$item->loadData($basket, $currency);
 			$this->_lineItems[] = $item;
 		}
+
+		Enlight()->Events()->notify(
+			__CLASS__ . '_AfterLoad',
+			array(
+				'nostoCart' => $this,
+				'baskets'   => $baskets,
+				'currency'  => $currency,
+			)
+		);
 	}
 
 	/**

--- a/Components/Model/Cart/LineItem.php
+++ b/Components/Model/Cart/LineItem.php
@@ -93,6 +93,15 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Cart_LineItem exte
 		$this->_quantity = (int)$basket->getQuantity();
 		$this->_unitPrice = Nosto::helper('price')->format($basket->getPrice());
 		$this->_currencyCode = strtoupper($currencyCode);
+
+		Enlight()->Events()->notify(
+			__CLASS__ . '_AfterLoad',
+			array(
+				'nostoCartLineItem' => $this,
+				'basket'            => $basket,
+				'currency'          => $currencyCode,
+			)
+		);
 	}
 
 	/**

--- a/Components/Model/Cart/LineItem.php
+++ b/Components/Model/Cart/LineItem.php
@@ -153,4 +153,97 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Cart_LineItem exte
 	{
 		return $this->_currencyCode;
 	}
+
+	/**
+	 * Sets the product ID for the given cart item.
+	 * The product ID must be an integer above zero.
+	 *
+	 * Usage:
+	 * $object->setProductId(1);
+	 *
+	 * @param int $id the product ID.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setProductId($id)
+	{
+		$this->_productId = $id;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the quantity for the given cart item.
+	 * The quantity must be an integer above zero.
+	 *
+	 * Usage:
+	 * $object->setQuantity(1);
+	 *
+	 * @param int $quantity the quantity.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setQuantity($quantity)
+	{
+		$this->_quantity = $quantity;
+
+		return $this;
+	}
+
+	/**
+	 * Sets cart items name.
+	 *
+	 * The name must be a non-empty string.
+	 *
+	 * Usage:
+	 * $object->setName('My product');
+	 *
+	 * @param string $name the name.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setName($name)
+	{
+		$this->_name = $name;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the unit price of the cart item.
+	 *
+	 * The price must be a numeric value
+	 *
+	 * Usage:
+	 * $object->setPrice(99.99);
+	 *
+	 * @param double $unitPrice the price.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setPrice($unitPrice)
+	{
+		$this->_unitPrice = $unitPrice;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the currency code (ISO 4217) the cart item is sold in.
+	 *
+	 * The currency must be in ISO 4217 format
+	 *
+	 * Usage:
+	 * $object->setCurrency('USD');
+	 *
+	 * @param string $currency the currency code.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setCurrencyCode($currency)
+	{
+		$this->_currencyCode = $currency;
+
+		return $this;
+	}
 }

--- a/Components/Model/Category.php
+++ b/Components/Model/Category.php
@@ -99,4 +99,23 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Category extends S
 	{
 		return $this->_categoryPath;
 	}
+
+	/**
+	 * Sets the category path.
+	 *
+	 * The category path must be a non-empty string.
+	 *
+	 * Usage:
+	 * $object->setCategoryPath('Sports/Winter');
+	 *
+	 * @param string $categoryPath the category path.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setCategoryPath($categoryPath)
+	{
+		$this->_categoryPath = $categoryPath;
+
+		return $this;
+	}
 }

--- a/Components/Model/Category.php
+++ b/Components/Model/Category.php
@@ -58,6 +58,14 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Category extends S
 	public function loadData(\Shopware\Models\Category\Category $category)
 	{
 		$this->_categoryPath = $this->buildCategoryPath($category);
+
+		Enlight()->Events()->notify(
+			__CLASS__ . '_AfterLoad',
+			array(
+				'nostoCategory' => $this,
+				'category'      => $category,
+			)
+		);
 	}
 
 	/**

--- a/Components/Model/Customer.php
+++ b/Components/Model/Customer.php
@@ -65,11 +65,19 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Customer extends S
 	 *
 	 * @param \Shopware\Models\Customer\Customer $customer the customer model.
 	 */
-	public function loadData(\Shopware\Models\Customer\Customer $customer )
+	public function loadData(\Shopware\Models\Customer\Customer $customer)
 	{
 		$this->_firstName = $customer->getBilling()->getFirstName();
 		$this->_lastName = $customer->getBilling()->getLastName();
 		$this->_email = $customer->getEmail();
+
+		Enlight()->Events()->notify(
+			__CLASS__ . '_AfterLoad',
+			array(
+				'nostoCustomer' => $this,
+				'customer'      => $customer,
+			)
+		);
 	}
 
 	/**

--- a/Components/Model/Customer.php
+++ b/Components/Model/Customer.php
@@ -103,4 +103,61 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Customer extends S
 	{
 		return $this->_email;
 	}
+
+	/**
+	 * Sets the firstname of the customer.
+	 *
+	 * The name must be a non-empty string.
+	 *
+	 * Usage:
+	 * $object->setFirstName('John');
+	 *
+	 * @param string $firstName the firstname.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setFirstName($firstName)
+	{
+		$this->_firstName = $firstName;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the lastname of the customer.
+	 *
+	 * The name must be a non-empty string.
+	 *
+	 * Usage:
+	 * $object->setLastName('Doe');
+	 *
+	 * @param string $lastName the lastname.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setLastName($lastName)
+	{
+		$this->_lastName = $lastName;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the email of the customer.
+	 *
+	 * The email must be a non-empty string.
+	 *
+	 * Usage:
+	 * $object->setEmail('john@doe.com');
+	 *
+	 * @param string $email the email.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setEmail($email)
+	{
+		$this->_email = $email;
+
+		return $this;
+	}
 }

--- a/Components/Model/Order.php
+++ b/Components/Model/Order.php
@@ -201,4 +201,118 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order extends Shop
 	{
 		return $this->_orderStatus;
 	}
+
+	/**
+	 * Sets the ordernumber.
+	 *
+	 * The ordernumber must be a non-empty string.
+	 *
+	 * Usage:
+	 * $object->setOrderNumber('123456');
+	 *
+	 * @param string $orderNumber the ordernumber.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setOrderNumber($orderNumber)
+	{
+		$this->_orderNumber = $orderNumber;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the created date of the order.
+	 *
+	 * The created date must be a non-empty string in format Y-m-d.
+	 *
+	 * Usage:
+	 * $object->setCreatedDate('2016-01-20');
+	 *
+	 * @param string $createdDate the created date.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setCreatedDate($createdDate)
+	{
+		$this->_orderNumber = $createdDate;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the payment provider of the order.
+	 *
+	 * The payment provider must be a non-empty string.
+	 *
+	 * Usage:
+	 * $object->setPaymentProvider('invoice');
+	 *
+	 * @param string $paymentProvider the payment provider.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setPaymentProvider($paymentProvider)
+	{
+		$this->_paymentProvider = $paymentProvider;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the buyer information for the order.
+	 *
+	 * The buyer information must be an instance of Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_Buyer.
+	 *
+	 * Usage:
+	 * $object->setBuyerInfo(new Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_Buyer());
+	 *
+	 * @param Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_Buyer $buyerInfo the buyer info.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setBuyerInfo($buyerInfo)
+	{
+		$this->_buyerInfo = $buyerInfo;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the purchased items for the order.
+	 *
+	 * The line items must be an array of Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_LineItem
+	 *
+	 * Usage:
+	 * $object->setPurchasedItems([new Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_LineItem(), ...]);
+	 *
+	 * @param Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_LineItem[] $purchasedItems the purchased items.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setPurchasedItems($purchasedItems)
+	{
+		$this->_purchasedItems = $purchasedItems;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the order status.
+	 *
+	 * The order status must be an instance of Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_Status.
+	 *
+	 * Usage:
+	 * $object->setOrderStatus(new Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_Status());
+	 *
+	 * @param Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_Status $orderStatus the buyer info.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setOrderStatus($orderStatus)
+	{
+		$this->_orderStatus = $orderStatus;
+
+		return $this;
+	}
 }

--- a/Components/Model/Order.php
+++ b/Components/Model/Order.php
@@ -135,6 +135,14 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order extends Shop
 				$this->_purchasedItems[] = $item;
 			}
 		}
+
+		Enlight()->Events()->notify(
+			__CLASS__ . '_AfterLoad',
+			array(
+				'nostoOrder' => $this,
+				'order'      => $order,
+			)
+		);
 	}
 
 	/**

--- a/Components/Model/Order/Buyer.php
+++ b/Components/Model/Order/Buyer.php
@@ -71,6 +71,14 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_Buyer extend
 		$this->_firstName = $customer->getBilling()->getFirstName();
 		$this->_lastName = $customer->getBilling()->getLastName();
 		$this->_email = $customer->getEmail();
+
+		Enlight()->Events()->notify(
+			__CLASS__ . '_AfterLoad',
+			array(
+				'nostoOrderBuyer' => $this,
+				'customer'        => $customer,
+			)
+		);
 	}
 
 	/**

--- a/Components/Model/Order/Buyer.php
+++ b/Components/Model/Order/Buyer.php
@@ -104,4 +104,61 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_Buyer extend
 	{
 		return $this->_email;
 	}
+
+	/**
+	 * Sets the firstname of the buyer.
+	 *
+	 * The name must be a non-empty string.
+	 *
+	 * Usage:
+	 * $object->setFirstName('John');
+	 *
+	 * @param string $firstName the firstname.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setFirstName($firstName)
+	{
+		$this->_firstName = $firstName;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the lastname of the buyer.
+	 *
+	 * The name must be a non-empty string.
+	 *
+	 * Usage:
+	 * $object->setLastName('Doe');
+	 *
+	 * @param string $lastName the lastname.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setLastName($lastName)
+	{
+		$this->_lastName = $lastName;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the email of the buyer.
+	 *
+	 * The email must be a non-empty string.
+	 *
+	 * Usage:
+	 * $object->setEmail('john@doe.com');
+	 *
+	 * @param string $email the email.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setEmail($email)
+	{
+		$this->_email = $email;
+
+		return $this;
+	}
 }

--- a/Components/Model/Order/LineItem.php
+++ b/Components/Model/Order/LineItem.php
@@ -94,6 +94,14 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_LineItem ext
 		$this->_quantity = (int)$detail->getQuantity();
 		$this->_unitPrice = Nosto::helper('price')->format($detail->getPrice());
 		$this->_currencyCode = strtoupper($detail->getOrder()->getCurrency());
+
+		Enlight()->Events()->notify(
+			__CLASS__ . '_AfterLoad',
+			array(
+				'nostoOrderLineItem' => $this,
+				'detail'             => $detail,
+			)
+		);
 	}
 
 	/**

--- a/Components/Model/Order/LineItem.php
+++ b/Components/Model/Order/LineItem.php
@@ -159,4 +159,97 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_LineItem ext
 	{
 		return $this->_currencyCode;
 	}
+
+	/**
+	 * Sets the product ID for the given cart item.
+	 * The product ID must be an integer above zero.
+	 *
+	 * Usage:
+	 * $object->setProductId(1);
+	 *
+	 * @param int $id the product ID.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setProductId($id)
+	{
+		$this->_productId = $id;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the quantity for the given cart item.
+	 * The quantity must be an integer above zero.
+	 *
+	 * Usage:
+	 * $object->setQuantity(1);
+	 *
+	 * @param int $quantity the quantity.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setQuantity($quantity)
+	{
+		$this->_quantity = $quantity;
+
+		return $this;
+	}
+
+	/**
+	 * Sets cart items name.
+	 *
+	 * The name must be a non-empty string.
+	 *
+	 * Usage:
+	 * $object->setName('My product');
+	 *
+	 * @param string $name the name.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setName($name)
+	{
+		$this->_name = $name;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the unit price of the cart item.
+	 *
+	 * The price must be a numeric value
+	 *
+	 * Usage:
+	 * $object->setPrice(99.99);
+	 *
+	 * @param double $unitPrice the price.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setPrice($unitPrice)
+	{
+		$this->_unitPrice = $unitPrice;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the currency code (ISO 4217) the cart item is sold in.
+	 *
+	 * The currency must be in ISO 4217 format
+	 *
+	 * Usage:
+	 * $object->setCurrency('USD');
+	 *
+	 * @param string $currency the currency code.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setCurrencyCode($currency)
+	{
+		$this->_currencyCode = $currency;
+
+		return $this;
+	}
 }

--- a/Components/Model/Order/Status.php
+++ b/Components/Model/Order/Status.php
@@ -105,4 +105,42 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_Status exten
 	{
 		return $this->_label;
 	}
-} 
+
+	/**
+	 * Sets the code of the order.
+	 *
+	 * The code must be a non-empty string.
+	 *
+	 * Usage:
+	 * $object->setCode('offen');
+	 *
+	 * @param string $code the code.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setCode($code)
+	{
+		$this->_code = $code;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the label of the order.
+	 *
+	 * The label must be a non-empty string.
+	 *
+	 * Usage:
+	 * $object->setLabel('Offen');
+	 *
+	 * @param string $label the label.
+	 *
+	 * @return $this Self for chaining
+	 */
+	public function setLabel($label)
+	{
+		$this->_label = $label;
+
+		return $this;
+	}
+}

--- a/Components/Model/Order/Status.php
+++ b/Components/Model/Order/Status.php
@@ -66,6 +66,14 @@ class Shopware_Plugins_Frontend_NostoTagging_Components_Model_Order_Status exten
 		$description = $order->getOrderStatus()->getDescription();
 		$this->_code = $this->convertDescriptionToCode($description);
 		$this->_label = $description;
+
+		Enlight()->Events()->notify(
+			__CLASS__ . '_AfterLoad',
+			array(
+				'nostoOrderStatus' => $this,
+				'order'            => $order,
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Status quo: Right now, it's not possible to change certain information in the order or in the cart object. It's just possible when the view implementations of the cart and/or order are overwritten.

Solution: All models will trigger an AfterLoad event now, when they're initialized. Based on that, all models will now have setter methods in order to change information.